### PR TITLE
Add links to internal tools, software and docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@ This is a collection of links that are helpful reading for people joining the Gu
 * [Big brother](http://octhelp/inventory/bigbrother) - for finding people ;) - only really works with people on desktops
 
 ## Useful Docs
-* [Department admin guide](https://docs.google.com/document/d/1ErsZUEL0ELiGUYXHbEWlm0mLGY7lZoAnzF4IXWqnPG0/editr)
-* [Socials/Events/Activities](https://docs.google.com/document/d/1aHFEtlXG0f-R12S0SPBzLXa1JnRpIJYjactHaYjmyGk/edit)
+* [Department admin guide](https://docs.google.com/document/d/1ErsZUEL0ELiGUYXHbEWlm0mLGY7lZoAnzF4IXWqnPG0/)
+* [Socials/Events/Activities](https://docs.google.com/document/d/1aHFEtlXG0f-R12S0SPBzLXa1JnRpIJYjactHaYjmyGk/)
 
 ## Development tools
-*[TeamCity](https://teamcity.gutools.co.uk/)
-*[RiffRaff](http://riffraff.gutools.co.uk/)
-*[Janus](https://janus.gutools.co.uk/) - for AWS access
+* [TeamCity](https://teamcity.gutools.co.uk/) - the current continuous integration system - see how your build is getting on.
+* [RiffRaff](http://riffraff.gutools.co.uk/) - for deploying your code
+* [Janus](https://janus.gutools.co.uk/) - access AWS using your google auth login
 
 ## Software
-* Teleporter [Firefox](https://s3-eu-west-1.amazonaws.com/gustaf-dist/composer/index.html), [Chrome](https://chrome.google.com/webstore/detail/guardian-staff-extension/hgdefnifioidkaphoeplpjinodnbbmfg?authuser=0)
-* [Prism/Marauder](https://github.com/guardian/prism/tree/master/marauder)
+* Teleporter [Firefox](https://s3-eu-west-1.amazonaws.com/gustaf-dist/composer/index.html), [Chrome](https://chrome.google.com/webstore/detail/guardian-staff-extension/hgdefnifioidkaphoeplpjinodnbbmfg?authuser=0) - browser extension for jumping between guardian content in the Content API/Composer/Frontend/Ophan and more
+* [Prism/Marauder](https://github.com/guardian/prism/tree/master/marauder) - For finding instances in AWS/GC2
+
+## Other
+* [Free Guardian Membership](https://membership.theguardian.com/join/staff) - including a guardian canvas bag!

--- a/README.md
+++ b/README.md
@@ -7,3 +7,22 @@ This is a collection of links that are helpful reading for people joining the Gu
 * [GitHub flow](https://guides.github.com/introduction/flow/)
 * [Creating use Git commit messages](http://chris.beams.io/posts/git-commit/)
 * [Git pickaxe](http://www.philandstuff.com/2014/02/09/git-pickaxe.html)
+
+## Internal Guardian Pages
+* [Spike](http://spike/) - Noticeboard, canteen food, HR policies, lots more
+* [GEE/Taleo](https://gnm.taleo.net/) - objectives
+* [Oracle Self Service](http://oracle.dmz.gnl:8079/OA_HTML/AppsLogin) - payslips and holiday booking
+* [Big brother](http://octhelp/inventory/bigbrother) - for finding people ;) - only really works with people on desktops
+
+## Useful Docs
+* [Department admin guide](https://docs.google.com/document/d/1ErsZUEL0ELiGUYXHbEWlm0mLGY7lZoAnzF4IXWqnPG0/editr)
+* [Socials/Events/Activities](https://docs.google.com/document/d/1aHFEtlXG0f-R12S0SPBzLXa1JnRpIJYjactHaYjmyGk/edit)
+
+## Development tools
+*[TeamCity](https://teamcity.gutools.co.uk/)
+*[RiffRaff](http://riffraff.gutools.co.uk/)
+*[Janus](https://janus.gutools.co.uk/) - for AWS access
+
+## Software
+* Teleporter [Firefox](https://s3-eu-west-1.amazonaws.com/gustaf-dist/composer/index.html), [Chrome](https://chrome.google.com/webstore/detail/guardian-staff-extension/hgdefnifioidkaphoeplpjinodnbbmfg?authuser=0)
+* [Prism/Marauder](https://github.com/guardian/prism/tree/master/marauder)


### PR DESCRIPTION
After writing this I had a thought that this might be more for tutorials and the like rather than department links, but I think these are useful - there's minimal overlap with the dig dev admin guide.
