### PR TITLE
Update after-starting.md

### DIFF
--- a/after-starting.md
+++ b/after-starting.md
@@ -2,14 +2,15 @@
 
 ## Internal Guardian Pages
 * [Spike](http://spike/) - Noticeboard, canteen food, HR policies, lots more
-* [GEE/Taleo](https://gnm.taleo.net/) - objectives
+* [GEE/Taleo](https://gnm.taleo.net/) - personal development
 * [Oracle Self Service](http://oracle.dmz.gnl:8079/OA_HTML/AppsLogin) - payslips and holiday booking
 
 ## Useful Docs
 * [Department admin guide](https://docs.google.com/document/d/1ErsZUEL0ELiGUYXHbEWlm0mLGY7lZoAnzF4IXWqnPG0/)
+* [Digital team career progression framework](https://docs.google.com/spreadsheets/d/1e66TuObMmYGcZeGqIl-BdGjHj_cPb1SDA2s_F3iNz34/edit#gid=1) 
 * [Socials/Events/Activities](https://docs.google.com/document/d/1aHFEtlXG0f-R12S0SPBzLXa1JnRpIJYjactHaYjmyGk/)
 
-## Development tools
+## Development tools 
 * [TeamCity](https://teamcity.gutools.co.uk) - shared teamcity continuous integration system - see how your build is getting on.
 * [CircleCI](https://circleci.com/dashboard) - shared circleci continuous integration system - login with github
 * [RiffRaff](https://riffraff.gutools.co.uk/) - for deploying your code


### PR DESCRIPTION
I am trying to consolidate different onboarding docs into one place and since this repo already has links to most (both public facing and ones restricted to people who work here) keeping this repo up to date looked like a good place to start and we can link to this from the developers site. A github repo is also easy for everyone to update.

We seem to already have most links here, I've only added the career progression framework and updated purpose of taleo. I also found a doc explaining the career progression process for engineering but didn't link to it because it didn't seem to be up to date. 

The only thing I'm not sure what to do about is this new starters guide: https://sites.google.com/a/guardian.co.uk/dig-dev-new-starters-guide/ which repeats some of the information in this repository (development tools and software sections). We could delete these sections from this repository and just link to this site. Ideally we wouldn't have two sources of information but this one is not just for engineering but also for product/UX. The engineering section seems to be updated frequently but the UX/product section hasn't been updated since 2016 